### PR TITLE
Explicit room state getter function return type for haxe 4.2

### DIFF
--- a/src/io/colyseus/Room.hx
+++ b/src/io/colyseus/Room.hx
@@ -103,7 +103,7 @@ class Room<T> {
     }
 
     public var state (get, null): T;
-    function get_state () {
+    function get_state () : T {
         return this.serializer.getState();
     }
 


### PR DESCRIPTION
Closes #43.

Still not sure if this is a compiler bug or intentional in 4.2 (will have ask around and see) but this gets it compiling in the mean time!