### PR TITLE
Convert the protocol class into an enum abstract over an int

### DIFF
--- a/src/io/colyseus/Protocol.hx
+++ b/src/io/colyseus/Protocol.hx
@@ -1,21 +1,21 @@
 package io.colyseus;
 
-class Protocol {
+enum abstract Protocol(Int) to Int {
     // User-related (0~9)
-    public static var USER_ID = 1;
+    var USER_ID = 1;
 
     // Room-related (9~19)
-    public static var JOIN_REQUEST = 9;
-    public static var JOIN_ROOM = 10;
-    public static var ERROR = 11;
-    public static var LEAVE_ROOM = 12;
-    public static var ROOM_DATA = 13;
-    public static var ROOM_STATE = 14;
-    public static var ROOM_STATE_PATCH = 15;
+    var JOIN_REQUEST = 9;
+    var JOIN_ROOM = 10;
+    var ERROR = 11;
+    var LEAVE_ROOM = 12;
+    var ROOM_DATA = 13;
+    var ROOM_STATE = 14;
+    var ROOM_STATE_PATCH = 15;
 
     // Match-making related (20~29)
-    public static var ROOM_LIST = 20;
+    var ROOM_LIST = 20;
 
     // Generic messages (50~60)
-    public static var BAD_REQUEST = 50;
+    var BAD_REQUEST = 50;
 }


### PR DESCRIPTION
Closes #44.

Works around any name clashes with `ERROR` by converting the class into an enum abstract so the compiler will inline the values. Added an implicit `to Int` so this shouldn't be a breaking change for anyones code.