### PR TITLE
Prevent crash upon response.room being null.

### DIFF
--- a/src/io/colyseus/Client.hx
+++ b/src/io/colyseus/Client.hx
@@ -86,6 +86,14 @@ class Client {
 
     @:generic
     public function consumeSeatReservation<T>(response: Dynamic, stateClass: Class<T>, callback: (MatchMakeError, Room<T>)->Void) {
+        
+        // Prevents crashing upon .room being null. Can be caused if the server itself encounters an error making a room.
+        if (response.error != null)
+		{
+			callback(new MatchMakeError(response.code, response.error), null);
+			return;
+		}
+        
         var room: Room<T> = new Room<T>(response.room.name, stateClass);
 
         room.roomId = response.room.roomId;


### PR DESCRIPTION
Recently while trying out Colyseus for the first time, I had misconfigured the server by transpiling it to JavaScript before running instead of using `ts-node index.ts`. This caused the server to throw the error `Class constructor Room cannot be invoked without 'new'.` and crash the entire game.

The point of this pull request is to easily prevent crashes so developers can look back at their console & see the problem from the client itself. The act of reproducing this crash is the aforementioned transpiling to JavaScript.