### PR TITLE
reconnectionToken not properly checked if it exists

### DIFF
--- a/src/io/colyseus/Client.hx
+++ b/src/io/colyseus/Client.hx
@@ -123,7 +123,7 @@ class Client {
 
         var options = ["sessionId" => room.sessionId];
 
-        if (response.reconnectionToken) {
+        if (response.reconnectionToken != null) {
 			options.set("reconnectionToken", response.reconnectionToken);
         }
 


### PR DESCRIPTION
haxe doesnt have js like checking for fields so != null should be used instead