### PR TITLE
fixed npe in callbacks

### DIFF
--- a/src/io/colyseus/serializer/schema/Callbacks.hx
+++ b/src/io/colyseus/serializer/schema/Callbacks.hx
@@ -162,7 +162,7 @@ class SchemaCallbacks<T> {
 
         callbacks[key].push(callback);
 
-        return () -> callbacks[operationOrFieldName].remove(callback);
+        return () -> callbacks[key].remove(callback);
     }
 
     public function triggerCallbacks0(callbacks:Map<String, Array<Dynamic>>, op:Int) {


### PR DESCRIPTION
Fixes #69 

### Root Cause
In the `addCallback` method, the key used to store callbacks is computed as:
```
var key = (Std.isOfType(operationOrFieldName, String))
    ? operationOrFieldName
    : "#" + operationOrFieldName;
```
Callbacks are added using `callbacks[key]` (line 163), but the returned cancel function incorrectly uses the raw `operationOrFieldName` parameter instead of the computed key:
```
// line 165 (bug)
return () -> callbacks[operationOrFieldName].remove(callback);
```
When `onChange` passes `OPERATION.REPLACE` (an integer like `0`), the key becomes `"#0"`, but the cancel function tries `callbacks[0]` which is `undefined` — hence the `indexOf` error.